### PR TITLE
Take a package version from the git tag

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,8 +34,15 @@ jobs:
 
       - name: Set package version from Git tag
         run: |
-          POETRY_VERSION=$(git describe --tags $(git rev-list --tags --max-count=1))
-          poetry version $POETRY_VERSION
+          TAG_NAME="${GITHUB_REF_NAME:-}"
+          if [ -z "$TAG_NAME" ]; then
+            # Fallback for manual runs or when ref name isn't populated
+            TAG_NAME=$(git describe --tags --exact-match 2>/dev/null || git describe --tags --abbrev=0)
+          fi
+          # Strip a leading 'v' if present (allow tags like v1.2.3)
+          POETRY_VERSION=${TAG_NAME#v}
+          echo "Setting package version to $POETRY_VERSION from tag $TAG_NAME"
+          poetry version "$POETRY_VERSION"
 
       - name: Build package
         run: poetry build

--- a/pkonfig/__init__.py
+++ b/pkonfig/__init__.py
@@ -1,3 +1,5 @@
+from importlib import metadata as _metadata
+
 from pkonfig.config import Config
 from pkonfig.errors import ConfigError, ConfigTypeError, ConfigValueNotFoundError
 from pkonfig.fields import (
@@ -17,3 +19,31 @@ from pkonfig.fields import (
     Str,
 )
 from pkonfig.storage import *
+
+# Expose package version for documentation and consumers
+try:
+    __version__ = _metadata.version("pkonfig")
+except _metadata.PackageNotFoundError:  # pragma: no cover - not in an installed context
+    __version__ = "0.0.0"
+
+__all__ = [
+    "Config",
+    "ConfigError",
+    "ConfigTypeError",
+    "ConfigValueNotFoundError",
+    "Bool",
+    "Byte",
+    "ByteArray",
+    "Choice",
+    "DecimalField",
+    "EnumField",
+    "Field",
+    "File",
+    "Float",
+    "Folder",
+    "Int",
+    "LogLevel",
+    "PathField",
+    "Str",
+    "__version__",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pkonfig"
-version = "2.0.1"
+version = "0.0.0"
 description = "Pythonic agile application configuration helpers"
 authors = ["Nikita Gladkikh <gladkikh.nikita@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Package version exposed from the package and used for documentation is hard-codded in the pyproject.toml. The version used for the GitHub release is defined manually. Those versions potentially could be different. This PR unifies the package version flow and uses only the GitHub tag.