### PR TITLE
Add Vault JSON support to SecretFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - YYYY-mm-dd
 
 ### Added
+- Add Vault-native JSON support to `SecretFile` so `vault kv get -format=json` exports can be read and flattened directly
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ cfg = App(
 print(cfg.host, cfg.port, cfg.debug)
 # Env example: APP_PORT=9000 python app.py → 9000 overrides file/defaults
 # SecretFile example: secrets/api_key.txt → cfg.api_key == file contents
+# Vault export example: SecretFile("vault-export.json") reads vault kv get -format=json output
+# and exposes nested keys like cfg.database.password
 ```
 
 Install

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -151,7 +151,7 @@ toml_settings = Toml("config.toml", missing_ok=False)
 
 ### Secrets mounted as files (`SecretFile`)
 
-`SecretFile` reads either a single file or every file in a directory. Each filename stem becomes the config key and the raw file content becomes the value, which makes it a good fit for mounted secret volumes.
+`SecretFile` reads either a single file or every file in a directory. For normal secret files, each filename stem becomes the config key and the raw file content becomes the value, which makes it a good fit for mounted secret volumes.
 
 ```python
 from pkonfig.storage import SecretFile
@@ -159,6 +159,17 @@ from pkonfig.storage import SecretFile
 secrets = SecretFile("secrets", missing_ok=True)
 
 print(secrets[("api_key",)])  # reads secrets/api_key or secrets/api_key.txt
+```
+
+It also understands Vault-native JSON exported by `vault kv get -format=json`. In that case PKonfig reads the secret payload directly and flattens nested objects into dotted config paths instead of using the filename stem.
+
+```python
+from pkonfig.storage import SecretFile
+
+vault_export = SecretFile("vault-export.json")
+
+print(vault_export[("database", "password")])  # reads data.data.database.password from Vault KV v2 JSON
+print(vault_export[("api_key",)])              # reads top-level secret keys as config entries
 ```
 
 ## Ordering storages for precedence

--- a/pkonfig/storage/secret_file.py
+++ b/pkonfig/storage/secret_file.py
@@ -1,5 +1,7 @@
+import json
+from collections.abc import Mapping
 from pathlib import Path
-from typing import IO, Iterator
+from typing import IO, Any, Iterator, Optional
 
 from pkonfig.storage.base import FileStorage
 
@@ -13,12 +15,12 @@ class SecretFile(FileStorage):
 
     def load(self) -> None:
         if self.file.is_file():
-            self._actual_storage[(self.file.stem,)] = self._load_secret(self.file)
+            self._load_secret_file(self.file)
             return
 
         if self.file.is_dir():
             for path in self._iter_secret_files():
-                self._actual_storage[(path.stem,)] = self._load_secret(path)
+                self._load_secret_file(path)
             return
 
         if not self.missing_ok:
@@ -29,9 +31,51 @@ class SecretFile(FileStorage):
             if path.is_file():
                 yield path
 
+    def _load_secret_file(self, path: Path) -> None:
+        secret = path.read_text(encoding="utf-8")
+        vault_secret = self._extract_vault_secret(secret)
+        if vault_secret is not None:
+            self.flatten(vault_secret, tuple())
+            return
+        self._actual_storage[(path.stem,)] = secret
+
+    @classmethod
+    def _extract_vault_secret(cls, secret: str) -> Optional[Mapping[str, Any]]:
+        try:
+            payload = json.loads(secret)
+        except json.JSONDecodeError:
+            return None
+
+        if not isinstance(payload, Mapping):
+            return None
+
+        data = payload.get("data")
+        if not isinstance(data, Mapping):
+            return None
+
+        nested_data = data.get("data")
+        if isinstance(nested_data, Mapping) and "metadata" in data:
+            return nested_data
+
+        if cls._looks_like_vault_envelope(payload):
+            return data
+
+        return None
+
     @staticmethod
-    def _load_secret(path: Path) -> str:
-        return path.read_text(encoding="utf-8")
+    def _looks_like_vault_envelope(payload: Mapping[str, Any]) -> bool:
+        return any(
+            key in payload
+            for key in (
+                "request_id",
+                "lease_id",
+                "renewable",
+                "lease_duration",
+                "wrap_info",
+                "warnings",
+                "auth",
+            )
+        )
 
     def load_file_content(self, handler: IO) -> dict[str, str]:
         return {self.file.stem: handler.read()}

--- a/tests/unit/test_storage/test_secret_file.py
+++ b/tests/unit/test_storage/test_secret_file.py
@@ -1,3 +1,4 @@
+import json
 from collections import ChainMap
 
 import pytest
@@ -24,6 +25,79 @@ def test_secret_file_reads_single_file(tmp_path):
     storage = SecretFile(secret_file)
 
     assert storage[("database_password",)] == "hunter2"
+
+
+def test_secret_file_reads_vault_kv_v2_json_file(tmp_path):
+    secret_file = tmp_path / "vault-export.json"
+    secret_file.write_text(
+        json.dumps(
+            {
+                "request_id": "req-123",
+                "data": {
+                    "data": {
+                        "database": {"password": "hunter2"},
+                        "api_key": "super-secret",
+                    },
+                    "metadata": {"version": 1},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    storage = SecretFile(secret_file)
+
+    assert storage[("database", "password")] == "hunter2"
+    assert storage[("api_key",)] == "super-secret"
+    with pytest.raises(KeyError):
+        storage[("vault-export",)]
+
+
+def test_secret_file_reads_vault_kv_json_from_directory(tmp_path):
+    secrets_dir = tmp_path / "secrets"
+    secrets_dir.mkdir()
+    (secrets_dir / "vault.json").write_text(
+        json.dumps(
+            {
+                "request_id": "req-123",
+                "data": {
+                    "data": {"service": {"token": "abc123"}},
+                    "metadata": {"version": 1},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (secrets_dir / "username").write_text("alice", encoding="utf-8")
+
+    storage = SecretFile(secrets_dir)
+
+    assert storage[("service", "token")] == "abc123"
+    assert storage[("username",)] == "alice"
+
+
+def test_secret_file_reads_vault_kv_v1_json_file(tmp_path):
+    secret_file = tmp_path / "vault-kv1.json"
+    secret_file.write_text(
+        json.dumps(
+            {
+                "request_id": "req-123",
+                "lease_id": "",
+                "renewable": False,
+                "lease_duration": 0,
+                "data": {
+                    "database": {"password": "hunter2"},
+                    "api_key": "super-secret",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    storage = SecretFile(secret_file)
+
+    assert storage[("database", "password")] == "hunter2"
+    assert storage[("api_key",)] == "super-secret"
 
 
 def test_secret_file_respects_defaults(tmp_path):


### PR DESCRIPTION
## Summary
- add Vault-native JSON support to `SecretFile` for `vault kv get -format=json` exports
- flatten Vault KV v1 and v2 payloads into PKonfig keys while preserving normal file behavior and precedence
- document the new behavior in the README, tutorials, and changelog

## Validation
- `poetry run pytest tests/unit`
- `poetry run mypy pkonfig`
- `poetry run pylint pkonfig`
- `make docs-build`
- `poetry run pytest tests/compatibility/test_python_version_compatibility.py -k 3.9`
- one-at-a-time compatibility verification for Python 3.9, 3.10, 3.11, 3.12, 3.13, and 3.14 with Docker image cleanup between runs

## Notes
- `make check` did not run directly in this shell because `black` was not on PATH outside Poetry, so the equivalent Poetry-backed commands were run instead.
