### PR TITLE
Fix conda py.typed regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Vault-native JSON support to `SecretFile` so `vault kv get -format=json` exports can be read and flattened directly
 
 ### Changed
+- Fix the conda recipe regression test to check the installed `pkonfig` package for `py.typed` instead of assuming the source tree is present during conda test runs
 
 ### Removed
 

--- a/tests/unit/test_conda_recipe.py
+++ b/tests/unit/test_conda_recipe.py
@@ -1,3 +1,4 @@
+from importlib.resources import files
 from pathlib import Path
 
 
@@ -23,4 +24,4 @@ def test_conda_recipe_copies_meta_yaml_for_recipe_regression_checks() -> None:
 
 
 def test_package_declares_py_typed_marker() -> None:
-    assert Path("pkonfig/py.typed").is_file()
+    assert (files("pkonfig") / "py.typed").is_file()


### PR DESCRIPTION
## Summary
- fix the conda regression test to assert `py.typed` from the installed `pkonfig` package
- avoid depending on the source tree layout during conda's isolated test phase
- document the fix in the changelog

## Validation
- `poetry run pytest tests/unit/test_conda_recipe.py -q`
- `poetry run pytest tests/unit -q`
- `poetry run mypy pkonfig`
- `poetry run sphinx-build -b html docs docs/_build/html`
